### PR TITLE
Support Authentication of users from custom webserver

### DIFF
--- a/lib/pusher-client/socket.rb
+++ b/lib/pusher-client/socket.rb
@@ -25,6 +25,7 @@ module PusherClient
       @secure = false
       @connected = false
       @encrypted = options[:encrypted] || false
+      @private_auth_method = options[:private_auth_method]
 
       bind('pusher:connection_established') do |data|
         socket = JSON.parse(data)
@@ -156,9 +157,13 @@ module PusherClient
     end
 
     def get_private_auth(channel)
-      string_to_sign = @socket_id + ':' + channel.name
-      signature = HMAC::SHA256.hexdigest(@secret, string_to_sign)
-      return "#{@key}:#{signature}"
+      if (@private_auth_method.nil?)
+        string_to_sign = @socket_id + ':' + channel.name
+        signature = HMAC::SHA256.hexdigest(@secret, string_to_sign)
+        return "#{@key}:#{signature}"
+      else
+        return @private_auth_method.call(@socket_id, channel)
+      end
     end
 
     def get_presence_auth(channel)


### PR DESCRIPTION
In the case when a user authentication is provided by a backend webserver, rather than Pusher (as per http://pusher.com/docs/authenticating_users) this change allows a different mechanism to be specified to provide `key:signature` method.

Normal usage of the callback would be to post to a url, retrieve the auth token and pass it back as a returning parameter.
