### PR TITLE
Removed openssl-nonblock, as it is no longer necessary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,4 @@ source 'https://www.rubygems.org'
 gemspec
 
 gem 'json',             :platform => :ruby_18
-gem 'openssl-nonblock', :platform => :ruby_18
 gem 'ruby-debug19',     :platform => :ruby_19

--- a/README.rdoc
+++ b/README.rdoc
@@ -12,10 +12,6 @@ may be sent on. You can't just bind a global event without subscribing to any ch
 == Installation
   gem install pusher-client
   
-If you're using Ruby 1.8.7, then you'll also need the openssl-nonblock gem:
-
-  gem install openssl-nonblock
-
 == Single-Threaded Usage
 The application will pause at socket.connect and handle events from Pusher as they happen.
 

--- a/lib/pusher-client/websocket.rb
+++ b/lib/pusher-client/websocket.rb
@@ -2,7 +2,6 @@ require 'rubygems'
 require 'socket'
 require 'websocket'
 require 'openssl'
-require 'openssl/nonblock' if RUBY_VERSION == '1.8.7'
 
 module PusherClient
   class PusherWebSocket


### PR DESCRIPTION
It has been stated [here](https://github.com/travis-ci/travis/commit/fedb980ff0591c1229bab59f2801d604168fb6de#commitcomment-3731389) by the gem's author that openssl-nonblock is no longer necessary with any supported version of Ruby.
