### PR TITLE
Add send_channel_event method on socket for client channel events

### DIFF
--- a/lib/pusher-client/socket.rb
+++ b/lib/pusher-client/socket.rb
@@ -188,6 +188,12 @@ module PusherClient
       PusherClient.logger.debug("Pusher : sending event : #{payload}")
     end
 
+    def send_channel_event(channel, event_name, data)
+      payload = {'channel' => channel, 'event' => event_name, 'data' => data}.to_json
+      @connection.send(payload)
+      PusherClient.logger.debug("Pusher : sending channel event : #{payload}")
+    end
+
   protected
 
     def send_local_event(event_name, event_data, channel_name)


### PR DESCRIPTION
This gem appeared to have no way to trigger client events, so I added a method on the socket class called send_channel_event(channel, event, data) to allow client- and presence- events on private and presence channels.

send_event could not be used because the channel specification needed to be at the top level of the json message as per the pusher protocol at http://pusher.com/docs/pusher_protocol#channel-client-events.
