### PR TITLE
Mask outgoing data.

### DIFF
--- a/lib/pusher-client/websocket.rb
+++ b/lib/pusher-client/websocket.rb
@@ -54,7 +54,7 @@ module PusherClient
     def send(data, type = :text)
       raise "no handshake!" unless @handshaked
 
-      data = WebSocket::Frame::Outgoing::Server.new(:version => @hs.version, :data => data, :type => type).to_s
+      data = WebSocket::Frame::Outgoing::Client.new(:version => @hs.version, :data => data, :type => type).to_s
       @socket.write data
       @socket.flush
     end


### PR DESCRIPTION
According to [rfc6455](http://tools.ietf.org/html/rfc6455#section-5.2), data from client to server must be masked,

This PR uses the `Client` class instead of the `Server` class of the `websocket` library for outgoing data frames in order to send masked payload.
