### PR TITLE
Retain a consistent code style

### DIFF
--- a/lib/pusher-client/channel.rb
+++ b/lib/pusher-client/channel.rb
@@ -24,24 +24,24 @@ module PusherClient
     end
 
     def dispatch(event_name, data)
-      PusherClient.logger.debug "Dispatching callbacks for #{event_name}"
+      PusherClient.logger.debug("Dispatching callbacks for #{event_name}")
       if @callbacks[event_name]
         @callbacks[event_name].each do |callback|
           callback.call(data)
         end
       else
-        PusherClient.logger.debug "No callbacks to dispatch for #{event_name}"
+        PusherClient.logger.debug("No callbacks to dispatch for #{event_name}")
       end
     end
 
     def dispatch_global_callbacks(event_name, data)
       if @global_callbacks[event_name]
-        PusherClient.logger.debug "Dispatching global callbacks for #{event_name}"
+        PusherClient.logger.debug("Dispatching global callbacks for #{event_name}")
         @global_callbacks[event_name].each do |callback|
           callback.call(data)
         end
       else
-        PusherClient.logger.debug "No global callbacks to dispatch for #{event_name}"
+        PusherClient.logger.debug("No global callbacks to dispatch for #{event_name}")
       end
     end
 

--- a/lib/pusher-client/channels.rb
+++ b/lib/pusher-client/channels.rb
@@ -8,10 +8,7 @@ module PusherClient
     end
 
     def add(channel_name)
-      unless @channels[channel_name]
-        @channels[channel_name] = Channel.new(channel_name)
-      end
-      @channels[channel_name]
+      @channels[channel_name] ||= Channel.new(channel_name)
     end
 
     def find(channel_name)

--- a/lib/pusher-client/websocket.rb
+++ b/lib/pusher-client/websocket.rb
@@ -54,7 +54,11 @@ module PusherClient
     def send(data, type = :text)
       raise "no handshake!" unless @handshaked
 
-      data = WebSocket::Frame::Outgoing::Server.new(:version => @hs.version, :data => data, :type => type).to_s
+      data = WebSocket::Frame::Outgoing::Server.new(
+        :version => @hs.version,
+        :data => data,
+        :type => type
+      ).to_s
       @socket.write data
       @socket.flush
     end


### PR DESCRIPTION
Retain a consistent code style with the rest of the code and ruby's unofficial styling.

Most of the changes are motivated by earlier style used in the code, and sometimes by what's common ruby style, e.g. do/end instead of brackets for several rows when precedence isn't an issue.
