### PR TITLE
Allow websocket to be any 1.x version

### DIFF
--- a/pusher-client.gemspec
+++ b/pusher-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths    = ['lib']
   s.licenses         = ['MIT']
 
-  s.add_runtime_dependency 'websocket', '~> 1.1.2'
+  s.add_runtime_dependency 'websocket', '~> 1.0'
   s.add_runtime_dependency 'json'
 
   s.add_development_dependency "rspec"


### PR DESCRIPTION
Specs pass well with 1.0.x and this avoids conflicts with gems not recently updated and only requiring websocket 1.0.x (selenium-webdriver for instance) 
