### PR TITLE
Add secure hash key in addition to encrypted

### DIFF
--- a/lib/pusher-client/socket.rb
+++ b/lib/pusher-client/socket.rb
@@ -21,7 +21,7 @@ module PusherClient
       @global_channel = Channel.new('pusher_global_channel')
       @global_channel.global = true
       @connected = false
-      @encrypted = options[:encrypted] || false
+      @encrypted = options[:encrypted] || options[:secure] || false
       @logger = options[:logger] || PusherClient.logger
       # :private_auth_method is deprecated
       @auth_method = options[:auth_method] || options[:private_auth_method]


### PR DESCRIPTION
Allow `secure` to be specified in the options hash to force encrypted connections.

Previously, the option was `encrypted`, but the docs were outdated. @zimbatm suggested adding support for both options.